### PR TITLE
Create a page for each tag (closes #24)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "jekyll"
 gem "webrick", "~> 1.7"
 gem 'jekyll-feed'
 gem 'jekyll-seo-tag'
+gem 'jekyll-datapage-generator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-datapage-generator (1.4.0)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.0.0)
@@ -69,6 +70,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-datapage-generator
   jekyll-feed
   jekyll-seo-tag
   webrick (~> 1.7)

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ collections:
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-datapage-generator
 
 defaults:
   - 
@@ -16,3 +17,10 @@ defaults:
       # layout: default
 
 #excerpt_separator: <!--more-->
+
+page_gen_dirs: false
+page_gen:
+  - data: tags
+    template: tag
+    dir: tags
+    name: name

--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,5 @@ page_gen:
     template: tag
     dir: tags
     name: name
+    title_expr: |-
+      record.fetch("displayname", record["name"])

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -2,7 +2,8 @@
   class: badge-swift
 - name: jekyll
   class: badge-danger
-  description: when i use jekyll
+  description: |-
+    the static site generator that powers this site. <a href="https://jekyllrb.com">jekyllrb.com</a>
 - name: java
   class: badge-java
 - name: rust

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -46,5 +46,3 @@
 - name: homebrew
 - name: macports
 - name: alacritty
-- name: draft
-  class: badge-orange

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -2,6 +2,7 @@
   class: badge-swift
 - name: jekyll
   class: badge-danger
+  description: when i use jekyll
 - name: java
   class: badge-java
 - name: rust
@@ -18,3 +19,27 @@
   class: badge-python
 - name: nixos
   class: badge-nix
+- name: frc
+- name: the blog
+- name: swift package manager
+- name: macos
+- name: neovim
+- name: sudo
+- name: shell
+- name: discord
+- name: rss
+- name: rssbot
+- name: refind
+- name: catppuccin
+- name: svg
+- name: imagemagick
+- name: ssh
+- name: gnupg
+- name: tailscale
+- name: wireguard
+- name: vpn
+- name: homebrew
+- name: macports
+- name: alacritty
+- name: draft
+  class: badge-orange

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -23,12 +23,17 @@
 - name: the blog
 - name: swift package manager
 - name: macos
+  displayname: macOS
+  description: |-
+    apple's desktop platform. my posts about it generally fall into one of two categories: tracking down bugs or doing complex configuration
 - name: neovim
 - name: sudo
 - name: shell
 - name: discord
 - name: rss
 - name: rssbot
+  description: |-
+    a discord bot that watches RSS/Atom feeds. find it on GitHub <a href="https://github.com/Samasaur1/rssbot">here</a>
 - name: refind
 - name: catppuccin
 - name: svg

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,0 +1,23 @@
+<{{ include.tag | default: "h3" }}>
+  <a href="{{ post.url }}">{{ post.title }}</a>&nbsp;
+  <span style="font-size: 50%;">
+    <span class="text-muted">{{ post.date | date_to_string }}</span>
+  </span>
+  <span style="font-size: 55%;">
+    {% if post.tags[0] %}
+      {% for tag in post.tags %}
+        {% assign css-class = "badge-secondary" %}
+        {% for site_tag in site.data.tags %}
+          {% if site_tag.name == tag %}
+            {% if site_tag.class %}
+              {% assign css-class = site_tag.class %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+        <a href="{{ "/tags/" | append: tag | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
+      {% endfor %}
+    {% endif %}
+  </span>
+</{{ include.tag | default: "h3" }}>
+
+{{ post.excerpt }}

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,7 +1,7 @@
 <{{ include.tag | default: "h3" }}>
   <a href="{{ post.url }}">{{ post.title }}</a>&nbsp;
   <span style="font-size: 50%;">
-    <span class="text-muted">{{ post.date | date_to_string }}</span>
+    <span class="text-muted">{{ post.date | date_to_string }}&nbsp;</span>
   </span>
   <span style="font-size: 55%;">
     {% if post.tags[0] %}
@@ -19,6 +19,11 @@
       {% endfor %}
     {% endif %}
   </span>
+  {% if post.last_updated %}
+    <span style="font-size: 50%;">
+      <span class="text-muted">&nbsp;updated {{ post.last_updated | date_to_string }}</span>
+    </span>
+  {% endif %}
 </{{ include.tag | default: "h3" }}>
 
 {{ post.excerpt }}

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -14,7 +14,8 @@
             {% endif %}
           {% endif %}
         {% endfor %}
-        <a href="{{ "/tags/" | append: tag | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
+        {% capture link %}/tags/{{ tag | replace: " ", "-" }}{% endcapture %}
+        <a href="{{ link | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
       {% endfor %}
     {% endif %}
   </span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,9 @@
 layout: default
 ---
 <div id="post-main-content">
-<h1 class="mb-0 pb-0">{{ page.title }}</h1>
-<p class="mt-0 pt-0 text-muted">
-{{ page.date | date_to_string }}
+  <h1 class="mb-0 pb-0">{{ page.title }}</h1>
+  <p class="mt-0 pt-0 text-muted">
+  {{ page.date | date_to_string }}
   {% if page.tags[0] %}
     &nbsp;&nbsp;
     {% for tag in page.tags %}
@@ -20,7 +20,10 @@ layout: default
       <a href="{{ link | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
     {% endfor %}
   {% endif %}
-</p>
-<hr style="border: 1px solid;"/>
-{{ content }}
+  {% if page.last_updated %}
+    &nbsp;&nbsp;updated {{ page.last_updated | date_to_string }}
+  {% endif %}
+  </p>
+  <hr style="border: 1px solid;"/>
+  {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,8 @@ layout: default
           {% endif %}
         {% endif %}
       {% endfor %}
-      <a href="{{ "/tags/" | append: tag | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
+      {% capture link %}/tags/{{ tag | replace: " ", "-" }}{% endcapture %}
+      <a href="{{ link | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
     {% endfor %}
   {% endif %}
 </p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,9 @@ layout: default
       {% assign css-class = "badge-info" %}
       {% for site_tag in site.data.tags %}
         {% if site_tag.name == tag %}
-          {% assign css-class = site_tag.class %}
+          {% if site_tag.class %}
+            {% assign css-class = site_tag.class %}
+          {% endif %}
         {% endif %}
       {% endfor %}
       <a href="{{ "/tags/" | append: tag | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,16 +1,20 @@
 ---
 layout: default
 ---
-<h2>{{ page.title }}</h2>
-{% if page.description %}
-    {{ page.description }}
-{% endif %}
-<hr/>
-
-<ul>
-  {% for post in site.posts %}
-    {% if post.tags contains page.title %}
-      <li>{% include post.html tag="h4" %}</li>
-    {% endif %}
-  {% endfor %}
-</ul>
+<div id="tag-info">
+  <h2>{{ page.title }}</h2>
+  {% if page.description %}
+    <p class="pb-0 mb-0">{{ page.description }}</p>
+  {% endif %}
+</div>
+<hr class="mb-0 mt-0 pb-0 pt-0"/>
+<div id="tag-posts">
+  <h2>recent posts:</h2>
+  <ul>
+    {% for post in site.posts %}
+      {% if post.tags contains page._name %}
+        <li>{% include post.html tag="h4" %}</li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</div>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<h2>{{ page.title }}</h2>
+{% if page.description %}
+    {{ page.description }}
+{% endif %}
+<hr/>
+
+<ul>
+  {% for post in site.posts %}
+    {% if post.tags contains page.title %}
+      <li>{% include post.html tag="h4" %}</li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -38,6 +38,11 @@
   background-color: #7e7eff;
   color: #ffffff;
 }
+.badge-orange {
+  background-color: #ff8c00;
+  // color: #0074ff;
+  color: #00ff00;
+}
 
 %icon {
   display: inline-block;

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -115,13 +115,21 @@ pre {
   background-color: lightgray;
 }
 
-#post-main-content {
-  padding: 1.5em;
-}
-
 blockquote {
   margin-left: 1em;
   border-left: 6px solid lightgray;
   padding-left: 1em;
   padding-top: 0.25em;
+}
+
+#post-main-content {
+  padding: 1.5em;
+}
+
+#tag-info {
+  padding: 1.5em;
+}
+
+#tag-posts {
+  padding: 1.5em;
 }

--- a/blog.html
+++ b/blog.html
@@ -14,27 +14,7 @@ title: Samasaur1 | Blog
 <ul>
   {% for post in site.posts %}
     <li>
-      <h3>
-        <a href="{{ post.url }}">{{ post.title }}</a>&nbsp;
-        <span style="font-size: 50%;">
-          <span class="text-muted">{{ post.date | date_to_string }}</span>
-        </span>
-        <span style="font-size: 55%;">
-          {% if post.tags[0] %}
-            {% for tag in post.tags %}
-              {% assign css-class = "badge-secondary" %}
-              {% for site_tag in site.data.tags %}
-                {% if site_tag.name == tag %}
-                  {% assign css-class = site_tag.class %}
-                {% endif %}
-              {% endfor %}
-              <a href="{{ "/tags/" | append: tag | relative_url }}" class="badge {{ css-class }}">{{ tag }}</a>
-            {% endfor %}
-          {% endif %}
-        </span>
-      </h3>
-
-      {{ post.excerpt }}
+      {% include post.html %}
     </li>
   {% endfor %}
 </ul>
@@ -43,7 +23,9 @@ title: Samasaur1 | Blog
   {% assign css-class = "badge-secondary" %}
   {% for site_tag in site.data.tags %}
     {% if site_tag.name == tag[0] %}
-      {% assign css-class = site_tag.class %}
+      {% if site_tag.class %}
+        {% assign css-class = site_tag.class %}
+      {% endif %}
     {% endif %}
   {% endfor %}
   <a href="{{ "/tags/" | append: tag[0] | relative_url }}" class="badge {{ css-class }}">{{ tag[0] }}</a>

--- a/blog.html
+++ b/blog.html
@@ -18,23 +18,24 @@ title: Samasaur1 | Blog
     </li>
   {% endfor %}
 </ul>
-<h2>Posts By Tag</h2>
-{% for tag in site.tags %}
-  {% assign css-class = "badge-secondary" %}
-  {% for site_tag in site.data.tags %}
-    {% if site_tag.name == tag[0] %}
-      {% if site_tag.class %}
-        {% assign css-class = site_tag.class %}
-      {% endif %}
-    {% endif %}
-  {% endfor %}
-  <a href="{{ "/tags/" | append: tag[0] | relative_url }}" class="badge {{ css-class }}">{{ tag[0] }}</a>
+<h2>Tags</h2>
   <ul>
-    {% for post in tag[1] %}
-      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% for tag in site.tags %}
+      {% assign css-class = "badge-secondary" %}
+      {% for site_tag in site.data.tags %}
+        {% if site_tag.name == tag[0] %}
+          {% if site_tag.class %}
+            {% assign css-class = site_tag.class %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      <li>
+        {% capture link %}/tags/{{ tag[0] | replace: " ", "-" }}{% endcapture %}
+        <a href="{{ link | relative_url }}" class="badge {{ css-class }}">{{ tag[0] }}</a>
+        ({{ tag[1] | size }})
+      </li>
     {% endfor %}
   </ul>
-{% endfor %}
 </div>
 <hr style="width: 90%;"/>
 <footer style="padding: 5px; text-align: center;">


### PR DESCRIPTION
These pages have a list of the recent posts from the blog which have been tagged with the given post. They also support a description, and may be customized with more in the future.

This PR also:
- extracts the HTML for a post in the list of posts to an include, so it can now be used on other pages
- shows the "last updated date" for posts that have it
- removes the list of "posts by tag" (superseded by the tag pages) and replaces it with a list of tags, showing the number of posts tagged with that tag