### PR TITLE
Add option to convert to local time; show time in comments

### DIFF
--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -15,7 +15,7 @@
       {{ comment.name | xml_escape }}
     {% endif %}
     &ndash;
-    <span class="text-muted" title="{{ comment.date | date_to_rfc822 }}">
+    <span class="text-muted" data-utc="{{ comment.date | date: "%FT%T%z" }}" id="comment-{{ comment.id }}">
       {{ comment.date | date: '%B' }}
       {% assign d = comment.date | date: "%-d" %}
       {% case d %}
@@ -25,11 +25,33 @@
         {% else %}{{d}}th,
       {% endcase %}
       {{ comment.date | date: '%Y' }}
-      {% comment %}
-        <!-- TODO: time -->
-        at
-        {{ comment.date | date: '%Y' }}
-      {% endcomment %}
+      at
+      {% assign no_tz = comment.date | date: '%l:%M %p' | strip %}
+      {% assign tz = comment.date | date: '%l:%M %p %Z' | strip %}
+      {{ comment.date | date: '%l:%M %p %Z' }}{% if tz == no_tz %} UTC{% endif %}
     </span>
+    <script>
+      el = document.getElementById("comment-{{ comment.id }}");
+      d = new Date(el.attributes["data-utc"].value);
+      local_date = new Intl.DateTimeFormat("en-GB", { dateStyle: "medium" }).format;
+      local_time = new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format;
+      site_date = new Intl.DateTimeFormat("en-GB", { dateStyle: "medium", timeZone: "{{ site.timezone }}"}).format;
+      site_time = new Intl.DateTimeFormat("en-US", { timeStyle: "short", timeZone: "{{ site.timezone }}"}).format;
+      el.attributes["date-local"] = local_date(d) + " at " + local_time(d);
+      el.attributes["date-sitetimezone"] = site_date(d) + " at " + site_time(d);
+      el.removeAttribute("data-utc");
+
+      convert = localStorage.getItem("convertToLocalTime");
+      if (convert === null) {
+        convert = false;
+        localStorage.setItem("convertToLocalTime", false);
+      } else if (convert === "true") {
+        convert = true;
+      } else {
+        convert = false;
+      }
+
+      el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
+    </script>
   </cite>
 </blockquote>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -59,11 +59,13 @@ layout: default
       </span>
       <script>
         convert = localStorage.getItem("convertToLocalTime");
-        if (!convert) {
+        if (convert === null) {
           convert = false;
           localStorage.setItem("convertToLocalTime", false);
-        } else {
+        } else if (convert === "true") {
           convert = true;
+        } else {
+          convert = false;
         }
         document.getElementById("localtime").checked = convert;
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,14 +3,15 @@ layout: default
 ---
 <div id="post-main-content">
   <h1 class="mb-0 pb-0">{{ page.title }}</h1>
-  <p class="mt-0 pt-0 text-muted">
+  <p class="mt-0 pt-0 text-muted pb-0 mb-0">
   <span data-utc="{{ page.date | date: "%FT%T%z" }}" id="post-date">{{ page.date | date: "%d %b %Y %l:%M %p" }}</span>
   <script type="text/javascript">
     el = document.getElementById("post-date");
     d = new Date(el.attributes["data-utc"].value);
     _date = new Intl.DateTimeFormat("en-GB", { dateStyle: "medium" }).format;
     _time = new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format;
-    el.innerHTML = _date(d) + " " + _time(d);
+    el.attributes["date-local"] = _date(d) + " " + _time(d);
+    el.attributes["date-sitetimezone"] = el.innerHTML;
     el.removeAttribute("data-utc");
   </script>
   {% if page.tags[0] %}
@@ -34,12 +35,62 @@ layout: default
       d = new Date(el.attributes["data-utc"].value);
       _date = new Intl.DateTimeFormat("en-GB", { dateStyle: "medium" }).format;
       _time = new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format;
-      el.innerHTML = _date(d) + " " + _time(d);
+      el.attributes["date-local"] = _date(d) + " " + _time(d);
+      el.attributes["date-sitetimezone"] = el.innerHTML;
       el.removeAttribute("data-utc");
     </script>
   {% endif %}
+    <script>
+      function updateCookie() {
+        convert = document.getElementById("localtime").checked;
+        document.cookie = "convertToLocalTime=" + convert + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
+        el = document.getElementById("post-date");
+        el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
+        {% if page.last_updated %}
+          el = document.getElementById("update-date");
+          el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
+        {% endif %}
+      }
+    </script>
+    <br/>
+    <span class="pb-0 pt-0 mb-0 mt-0" style="font-size: 60%;">
+      <input type="checkbox" name="localtime" id="localtime" checked onchange="updateCookie()" style="transform: scale(0.6) translateY(3px);"/>convert to local time zone
+    </span>
+    <script>
+      // source: https://www.w3schools.com/js/js_cookies.asp
+      function getCookie(cname) {
+        let name = cname + "=";
+        let decodedCookie = decodeURIComponent(document.cookie);
+        let ca = decodedCookie.split(';');
+        for(let i = 0; i <ca.length; i++) {
+          let c = ca[i];
+          while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+          }
+          if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+          }
+        }
+        return "";
+      }
+      convert = getCookie("convertToLocalTime");
+      if (convert === "") convert = false;
+      convert = convert === "true";
+      document.getElementById("localtime").checked = convert;
+    </script>
+    <script>
+      convert = document.getElementById("localtime").checked;
+      if (convert) {
+        el = document.getElementById("post-date");
+        el.innerHTML = el.attributes["date-local"];
+        {% if page.last_updated %}
+          el = document.getElementById("update-date");
+          el.innerHTML = el.attributes["date-local"];
+        {% endif %}
+      }
+    </script>
   </p>
-  <hr style="border: 1px solid;"/>
+  <hr class="mt-0 pt-0" style="border: 1px solid;"/>
   {{ content }}
   <hr style="border: 1px solid;"/>
   <div id="post-comments">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -43,7 +43,7 @@ layout: default
     <script>
       function updateCookie() {
         convert = document.getElementById("localtime").checked;
-        document.cookie = "convertToLocalTime=" + convert + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
+        localStorage.setItem("convertToLocalTime", convert);
         el = document.getElementById("post-date");
         el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
         {% if page.last_updated %}
@@ -57,29 +57,10 @@ layout: default
       <input type="checkbox" name="localtime" id="localtime" checked onchange="updateCookie()" style="transform: scale(0.6) translateY(3px);"/>convert to local time zone
     </span>
     <script>
-      // source: https://www.w3schools.com/js/js_cookies.asp
-      function getCookie(cname) {
-        let name = cname + "=";
-        let decodedCookie = decodeURIComponent(document.cookie);
-        let ca = decodedCookie.split(';');
-        for(let i = 0; i <ca.length; i++) {
-          let c = ca[i];
-          while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-          }
-          if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-          }
-        }
-        return "";
-      }
-      convert = getCookie("convertToLocalTime");
-      if (convert === "") convert = false;
-      convert = convert === "true";
+      convert = localStorage.getItem("convertToLocalTime");
+      if (!convert) convert = false;
       document.getElementById("localtime").checked = convert;
-    </script>
-    <script>
-      convert = document.getElementById("localtime").checked;
+
       if (convert) {
         el = document.getElementById("post-date");
         el.innerHTML = el.attributes["date-local"];

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div id="post-main-content">
   <h1 class="mb-0 pb-0">{{ page.title }}</h1>
-  <p class="mt-0 pt-0 text-muted pb-0 mb-0">
+  <p class="mt-0 pt-0 text-muted">
   <span data-utc="{{ page.date | date: "%FT%T%z" }}" id="post-date">{{ page.date | date: "%d %b %Y %l:%M %p" }}</span>
   <script type="text/javascript">
     el = document.getElementById("post-date");
@@ -40,38 +40,45 @@ layout: default
       el.removeAttribute("data-utc");
     </script>
   {% endif %}
-    <script>
-      function updateCookie() {
-        convert = document.getElementById("localtime").checked;
-        localStorage.setItem("convertToLocalTime", convert);
-        el = document.getElementById("post-date");
-        el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
-        {% if page.last_updated %}
-          el = document.getElementById("update-date");
+    <span style="display: none;">
+      <script>
+        function updateCookie() {
+          convert = document.getElementById("localtime").checked;
+          localStorage.setItem("convertToLocalTime", convert);
+          el = document.getElementById("post-date");
           el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
-        {% endif %}
-      }
-    </script>
-    <br/>
-    <span class="pb-0 pt-0 mb-0 mt-0" style="font-size: 60%;">
-      <input type="checkbox" name="localtime" id="localtime" checked onchange="updateCookie()" style="transform: scale(0.6) translateY(3px);"/>convert to local time zone
-    </span>
-    <script>
-      convert = localStorage.getItem("convertToLocalTime");
-      if (!convert) convert = false;
-      document.getElementById("localtime").checked = convert;
+          {% if page.last_updated %}
+            el = document.getElementById("update-date");
+            el.innerHTML = convert ? el.attributes["date-local"] : el.attributes["date-sitetimezone"];
+          {% endif %}
+        }
+      </script>
+      <br/>
+      <span class="pb-0 pt-0 mb-0 mt-0" style="font-size: 60%;">
+        <input type="checkbox" name="localtime" id="localtime" checked onchange="updateCookie()" style="transform: scale(0.6) translateY(3px);"/>convert to local time zone
+      </span>
+      <script>
+        convert = localStorage.getItem("convertToLocalTime");
+        if (!convert) {
+          convert = false;
+          localStorage.setItem("convertToLocalTime", false);
+        } else {
+          convert = true;
+        }
+        document.getElementById("localtime").checked = convert;
 
-      if (convert) {
-        el = document.getElementById("post-date");
-        el.innerHTML = el.attributes["date-local"];
-        {% if page.last_updated %}
-          el = document.getElementById("update-date");
+        if (convert) {
+          el = document.getElementById("post-date");
           el.innerHTML = el.attributes["date-local"];
-        {% endif %}
-      }
-    </script>
+          {% if page.last_updated %}
+            el = document.getElementById("update-date");
+            el.innerHTML = el.attributes["date-local"];
+          {% endif %}
+        }
+      </script>
+    </span>
   </p>
-  <hr class="mt-0 pt-0" style="border: 1px solid;"/>
+  <hr style="border: 1px solid;"/>
   {{ content }}
   <hr style="border: 1px solid;"/>
   <div id="post-comments">


### PR DESCRIPTION
This PR closes #28 and #34, as noted in the commits.

Before this PR, post date/times on the main page for each post were automatically converted from the site timezone to the local timezone, with no option to disable this other than disabling JavaScript entirely. This PR changes that behavior, storing a value in the user's `localStorage` that controls whether times should be converted from the site timezone to the local timezone (default false). It also adds a checkbox that controls this setting, but that checkbox is hidden because I'm not sure where I want to show it.

Additionally, this PR displays times on comments, which are converted from the comment time zone[^tz] to the site timezone, and also support being converted to the local timezone via the `localStorage` variable.

[^tz]: Although I initially wanted to support displaying comments in the commenter's time zone, I realized that this was infeasible for a number of reasons, chief among them that all comments appear to be in UTC since that is the timezone that my comments server is using.